### PR TITLE
Fixed: fails to import side-by-side with other instances of TlsCertificateValidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 # TlsCertificateValidation Changelog
 
+## 2.0.2
+
+TlsCertificateValidation fails to import side-by-side with other instances of TlsCertificateValidation.
+
 ## 2.0.1
+
+> Released 4 Dec 2024
 
 Removing unused internal, private, nested dependencies.
 

--- a/Source/ServerCertificateCallbackShim.cs
+++ b/Source/ServerCertificateCallbackShim.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 
-namespace TlsCertificateValidation
+namespace TlsCertificateValidation.v2
 {
     public static class ServerCertificateCallbackShim
     {
@@ -12,7 +12,7 @@ namespace TlsCertificateValidation
         {
             if( !write )
                 return;
-            
+
             Console.WriteLine(line);
         }
 
@@ -20,7 +20,8 @@ namespace TlsCertificateValidation
         {
             var enableConsoleOutput =
                 Environment.GetEnvironmentVariable("TLSCV_ENABLE_CONSOLE_OUTPUT");
-            return !string.IsNullOrEmpty(enableConsoleOutput);
+            return !string.IsNullOrEmpty(enableConsoleOutput) &&
+                   enableConsoleOutput.Equals(true.ToString(), StringComparison.InvariantCultureIgnoreCase);
         }
 
         public static void RegisterScriptBlockValidator(ScriptBlock validator)
@@ -52,7 +53,7 @@ namespace TlsCertificateValidation
                         WriteLine(write, "           returned   null");
                         return false;
                     }
-                    
+
                     var baseObject = result[0].BaseObject;
                     var msg = "           returned   ([" + baseObject.GetType().FullName + "] " + baseObject.ToString() +
                               ").";

--- a/Source/TlsCertificateValidation.csproj
+++ b/Source/TlsCertificateValidation.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>TlsCV-v2</AssemblyName>
     <OutputPath>bin\</OutputPath>
   </PropertyGroup>
 

--- a/TlsCertificateValidation/Functions/Set-TlsCertificateValidator.ps1
+++ b/TlsCertificateValidation/Functions/Set-TlsCertificateValidator.ps1
@@ -34,5 +34,5 @@ function Set-TlsCertificateValidator
 
     Set-StrictMode -Version 'Latest'
 
-    $script:serverCertCallbackShim::RegisterScriptBlockValidator($ScriptBlock)
+    [TlsCertificateValidation.v2.ServerCertificateCallbackShim]::RegisterScriptBlockValidator($ScriptBlock)
 }

--- a/TlsCertificateValidation/TlsCertificateValidation.psd1
+++ b/TlsCertificateValidation/TlsCertificateValidation.psd1
@@ -18,7 +18,7 @@
     RootModule = 'TlsCertificateValidation.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.0.1'
+    ModuleVersion = '2.0.2'
 
     # ID used to uniquely identify this module
     GUID = '41180ebf-f757-436d-87ed-437e23cc10b8'
@@ -68,7 +68,7 @@ can:
     # RequiredModules = @()
 
     # Assemblies that must be loaded prior to importing this module
-    RequiredAssemblies = @('bin\TlsCertificateValidation.dll')
+    RequiredAssemblies = @('bin\TlsCV-v2.dll')
 
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
     # ScriptsToProcess = @()

--- a/TlsCertificateValidation/TlsCertificateValidation.psm1
+++ b/TlsCertificateValidation/TlsCertificateValidation.psm1
@@ -18,20 +18,9 @@ Set-StrictMode -Version 'Latest'
 # Functions should use $moduleRoot as the relative root from which to find
 # things. A published module has its function appended to this file, while a
 # module in development has its functions in the Functions directory.
-$moduleRoot = $PSScriptRoot
+$script:moduleRoot = $PSScriptRoot
 
-$assemblyPath = Join-Path -Path $script:moduleRoot -ChildPath 'bin\TlsCertificateValidation.dll' -Resolve
-$assembly = [AppDomain]::CurrentDomain.GetAssemblies() | Where-Object 'Location' -EQ $assemblyPath
-$assemblyTypes = $assembly.GetTypes()
-$script:serverCertCallbackShim = $assemblyTypes | Where-Object 'Name' -EQ 'ServerCertificateCallbackShim'
-if (-not $script:serverCertCallbackShim)
-{
-    $msg = "Failed to find [TlsCertificateValidation.ServerCertificateCallbackShim] type from assembly " +
-           """${assemblyPath}""."
-    Write-Error -Message $msg
-}
-
-$functionsPath = Join-Path -Path $moduleRoot -ChildPath 'Functions\*.ps1'
+$functionsPath = Join-Path -Path $script:moduleRoot -ChildPath 'Functions\*.ps1'
 if( (Test-Path -Path $functionsPath) )
 {
     foreach( $functionPath in (Get-Item $functionsPath) )


### PR DESCRIPTION
This is a little bit of an experiment. Whenever we update the C# code to any part of an assembly that ships with a module, it must have a unique version number, which gets added to the namespace and assembly name. This way, PowerShell/.NET will load side-by-side versions of a module and as long as the module references/uses the specific version it needs, everything should work out.